### PR TITLE
Adjust link that was not functional anymore due to reorganization of …

### DIFF
--- a/content/docs/deploying/deploy-in-ci.md
+++ b/content/docs/deploying/deploy-in-ci.md
@@ -51,4 +51,4 @@ There are a few Docker images maintained by us that can be used for a CI pipelin
 
 ## Concourse Example
 
-You can see an example of how we combined these scripts in our own CI pipelines [here](https://github.com/cloudfoundry/cf-for-k8s/tree/main/ci/pipelines).
+You can see an example of how we combined these scripts in our own CI pipeline [here](https://github.com/cloudfoundry/cf-for-k8s/blob/main/ci/pipelines/cf-for-k8s-main.yml).

--- a/content/docs/deploying/deploy-in-ci.md
+++ b/content/docs/deploying/deploy-in-ci.md
@@ -51,4 +51,4 @@ There are a few Docker images maintained by us that can be used for a CI pipelin
 
 ## Concourse Example
 
-You can see an example of how we combined these scripts in our own CI pipeline [here](https://github.com/cloudfoundry/cf-for-k8s/blob/main/ci/pipelines/cf-for-k8s.yml).
+You can see an example of how we combined these scripts in our own CI pipelines [here](https://github.com/cloudfoundry/cf-for-k8s/tree/main/ci/pipelines).


### PR DESCRIPTION
…pipeline files

The adjusted URL is not functional anymore due to the changes made in here => https://github.com/cloudfoundry/cf-for-k8s/commit/5c841b17895eb809316e43b8f07d795f7e0d0368#diff-21e072aa0ca4d97577a6d94c19ec3ae36ac8f49d0e5858f3b8c9a25892af7ae2

As there is no pipeline including all the steps from before I adjusted it to just point to the path in the repo including all the pipeline.yml files, otherwise I could adjust to make it point to the cf-for-k8s-main file. 

Please let me know if that is preferred from your side. 